### PR TITLE
Increase Code Proficiency by Restricting Samtools Depth Input

### DIFF
--- a/WDL/CNV-Mag.wdl
+++ b/WDL/CNV-Mag.wdl
@@ -171,11 +171,11 @@ task SamtoolsDepth {
         # Create output directory
         mkdir output
 
-        declare -A BAMS=([CASE]=~{alignedBam} [HG001]=~{HG001Bam} [HG002]=~{HG002Bam})
-
-        for sample in "${!BAMS[@]}"; do
-            PATH="${BAMS[$sample]}"
-            samtools view -@ ~{cpu} -h ${PATH} --region-file ~{target_bed} -b -o ${sample}_aligned_region.bam
+        for bam in case:~{alignedBam} HG001:~{HG001Bam} HG002:~{HG002Bam}; do
+            sample=${bam%%:*}
+            path=${bam#*:}
+            samtools view -@ ~{cpu} -h -b --region-file ~{target_bed} ${path} -o ${sample}_aligned_region.bam
+            samtools index -@ ~{cpu} ${sample}_aligned_region.bam
         done
 
         # Run samtools depth to get MAPQ20 depth & MAPQ0 depth

--- a/WDL/CNV-Mag.wdl
+++ b/WDL/CNV-Mag.wdl
@@ -171,6 +171,15 @@ task SamtoolsDepth {
         # Create output directory
         mkdir output
 
+        samtools view -@ ~{cpu} -h ~{alignedBam} --region-file ~{target_bed} -b -o case_aligned_region.bam
+        samtools index case_aligned_region.bam
+
+        samtools view -@ ~{cpu} -h ~{HG001Bam} --region-file ~{target_bed} -b -o HG001_aligned_region.bam
+        samtools index HG001_aligned_region.bam
+
+        samtools view -@ ~{cpu} -h ~{HG002Bam} --region-file ~{target_bed} -b -o HG002_aligned_region.bam
+        samtools index HG002_aligned_region.bam
+
         # Run samtools depth to get MAPQ20 depth & MAPQ0 depth
         # Counting fragments instead of reads using -s option
         for mq in 0 20; do
@@ -180,9 +189,9 @@ task SamtoolsDepth {
             --min-BQ ~{minBQ} \
             --min-MQ ${mq} \
             -s \
-            ~{alignedBam} \
-            ~{HG001Bam} \
-            ~{HG002Bam} \
+            case_aligned_region.bam \
+            HG001_aligned_region.bam \
+            HG002_aligned_region.bam \
             -o output/~{sampleName}_MAPQ${mq}_samtools.depth;
         done
 

--- a/WDL/CNV-Mag.wdl
+++ b/WDL/CNV-Mag.wdl
@@ -171,14 +171,12 @@ task SamtoolsDepth {
         # Create output directory
         mkdir output
 
-        samtools view -@ ~{cpu} -h ~{alignedBam} --region-file ~{target_bed} -b -o case_aligned_region.bam
-        samtools index case_aligned_region.bam
+        declare -A BAMS=([CASE]=~{alignedBam} [HG001]=~{HG001Bam} [HG002]=~{HG002Bam})
 
-        samtools view -@ ~{cpu} -h ~{HG001Bam} --region-file ~{target_bed} -b -o HG001_aligned_region.bam
-        samtools index HG001_aligned_region.bam
-
-        samtools view -@ ~{cpu} -h ~{HG002Bam} --region-file ~{target_bed} -b -o HG002_aligned_region.bam
-        samtools index HG002_aligned_region.bam
+        for sample in "${!BAMS[@]}"; do
+            PATH="${BAMS[$sample]}"
+            samtools view -@ ~{cpu} -h ${PATH} --region-file ~{target_bed} -b -o ${sample}_aligned_region.bam
+        done
 
         # Run samtools depth to get MAPQ20 depth & MAPQ0 depth
         # Counting fragments instead of reads using -s option


### PR DESCRIPTION
Thanks to @kachulis pointing out the issues with Samtools depth. It reads through the entire BAM even when you pass a specific region file. The updated commands reduce the runtime of collecting depth of chrX from three bam files from 2h18m to 14m. 