### PR TITLE
Fix MagSNP for samples with incomplete FORMAT fields in DRAGEN VCF

### DIFF
--- a/MagScripts/MagSNP.py
+++ b/MagScripts/MagSNP.py
@@ -48,21 +48,17 @@ def annotate_af(vcf_path, interval, pass_only=True):
     interval_start = int(interval.split(":")[1].split("-")[0])
     interval_end = int(interval.split(":")[1].split("-")[1])
 
+    vcf = VariantFile(vcf_path)
+    sample_name = list(vcf.header.samples)[0]
     pos_af_list = []
-    with VariantFile(vcf_path) as vcf:
-        sample_name = list(vcf.header.samples)[0]
-        for rec in vcf.fetch(contig=interval_chr, start=interval_start, end=interval_end):
-            if pass_only:
-                if rec.filter.keys() == ['PASS'] and is_snp(rec):
-                    af = np.round(rec.samples[sample_name]["AF"][0], 2)
-                    pos_af_list.append((rec.pos, af))
-            else:
-                if is_snp(rec):
-                    af = np.round(rec.samples[sample_name]["AF"][0], 2)
-                    pos_af_list.append((rec.pos, af))
-
+    for rec in vcf.fetch(contig=interval_chr, start=interval_start, end=interval_end):
+        if is_snp(rec) and 'AF' in rec.samples[sample_name]:
+            if pass_only and rec.filter.keys() != ['PASS']:
+                continue
+            af = np.round(rec.samples[sample_name]["AF"][0], 2)
+            pos_af_list.append((rec.pos, af))
     if len(pos_af_list) == 0:
-        raise ValueError(f"No SNPs on {interval_chr} within {interval_start} and {interval_end}")
+        raise ValueError(f"No SNPs on {interval_chr} wihtin {interval_start} and {interval_end}")
 
     interval_pass_snp_df = pd.DataFrame(pos_af_list, columns=['POS', 'ALLELE_FRACTION'])
     return interval_pass_snp_df

--- a/WDL/CNV-Mag.wdl
+++ b/WDL/CNV-Mag.wdl
@@ -11,7 +11,7 @@ struct RuntimeAttributes {
 workflow CNV_Mag {
     input{
         String sampleName
-        String dockerImage = "us.gcr.io/tag-public/cnv-mag:v0.5"
+        String dockerImage = "us.gcr.io/tag-public/cnv-mag:v0.6"
         File cramOrBamFile
         File cramOrBamIndexFile
         String refGenome = "hg38"


### PR DESCRIPTION
BCL VA team reported SNP plots fail to generate for some samples with the error:

Here is the observed error:
```
Error processing interval chr1:19623311-26133645: 'invalid FORMAT: AF'
```

This occurs when DRAGEN VCF records lack the AF field in their FORMAT column. Analysis of an 800k region (chr16:34047-886086) showed ~1.5% of SNP records (24/1426) are missing this field.

I added a simple check to skip SNP records without a valid AF field, allowing plots to generate successfully with the remaining records.
